### PR TITLE
Only write target_pwm if it changed

### DIFF
--- a/fan-daemon.cpp
+++ b/fan-daemon.cpp
@@ -60,6 +60,7 @@ int main(int argc, char *argv[])
 {
     unsigned temp;
     unsigned pwmValue;
+    unsigned lastPwmValue = 0;
 
     pwmCap = getPwmCap();
 
@@ -71,7 +72,11 @@ int main(int argc, char *argv[])
     {
         temp = readAverageTemp();
         pwmValue = adjustFanSpeed( temp,  pwmCap);
-        writeIntSysFs(TARGET_PWM, pwmValue);
+        if (pwmValue != lastPwmValue)
+        {
+            writeIntSysFs(TARGET_PWM, pwmValue);
+            lastPwmValue = pwmValue;
+        }
         this_thread::sleep_for(chrono::milliseconds(UPDATE_INTERVAL * MICRO_SECONDS));
     }
 


### PR DESCRIPTION
Bill, first, thank you for this port of the fan controller!

This PR updates the code so that instead of writing to `/sys/devices/pwm-fan/target_pwm` every `UPDATE_INTERVAL` seconds it will only write to it if there was a change in fan speed.
